### PR TITLE
Update _common.scss

### DIFF
--- a/src/gtk-3.0/_common.scss
+++ b/src/gtk-3.0/_common.scss
@@ -1904,8 +1904,8 @@ headerbar {
 
 headerbar { // headerbar border rounding
   window:not(.tiled):not(.maximized):not(.solid-csd) separator:first-child + &, // tackles the paned container case
-  window:not(.tiled):not(.maximized):not(.solid-csd) &:first-child { &:backdrop, & { border-top-left-radius: 7px; }}
-  window:not(.tiled):not(.maximized):not(.solid-csd) &:last-child { &:backdrop, & { border-top-right-radius: 7px; }}
+  window:not(.tiled):not(.maximized):not(.solid-csd) &:first-child { &:backdrop, & { border-top-left-radius: 4px; }}
+  window:not(.tiled):not(.maximized):not(.solid-csd) &:last-child { &:backdrop, & { border-top-right-radius: 4px; }}
   window:not(.tiled):not(.maximized):not(.solid-csd) stack & { // tackles the stacked headerbars case
     &:first-child, &:last-child {
       &:backdrop, & {


### PR DESCRIPTION
Lowered radius of the headerbar to match window decoration's radius (line 4531).
This allow to fill the whole rounded upper corners and get rid of the annoying lack of filling that can be seen in the settings window of gnome-shell or gedit prior to this modification.